### PR TITLE
Add snippets for double-click, right-click, and asserting if the element is checked

### DIFF
--- a/snippets/assert-checked.js
+++ b/snippets/assert-checked.js
@@ -22,3 +22,4 @@ var actual = element.checked;
 if (actual !== expected) {
    throw new Error('Error: the actual(' + actual + ') does not match the expected(' + expected + ').');
 }
+

--- a/snippets/assert-checked.js
+++ b/snippets/assert-checked.js
@@ -1,0 +1,24 @@
+/* Locate the element
+ * 要素を探す */
+var selector = "<TODO: REPLACE SELECTOR>";
+var element  = document.querySelector(selector);
+
+/* Set expected value (Set true if you expect the element to be checked, otherwise set false)
+ * 期待する値を設定する (チェックされていることを期待する場合は true, されていないことを期待する場合は false を設定する)　*/
+var expected = true;
+
+/* Exit if it does not exist
+ * 要素がなければ処理を中断する */
+if (!element) {
+  throw new Error('Error: cannot find the element with selector(' + selector + ').');
+}
+
+/* Check if the element is checked
+ * 要素がチェックされているかどうかを取得する */
+var actual = element.checked;
+
+/* Exit if the actual value does not match the expected value
+ * 実際の値と期待する値が違う場合、処理を中断する */
+if (actual !== expected) {
+   throw new Error('Error: the actual(' + actual + ') does not match the expected(' + expected + ').');
+}

--- a/snippets/assert-checked.js
+++ b/snippets/assert-checked.js
@@ -1,11 +1,35 @@
+/* Usage of this snippet:
+ *   Use this snippet to assert that a checkable element
+ *   (such as a radio button implemented as <input type="radio">)
+ *   is checked or not, in case it is not possible with Recorder.
+ * 
+ *   Refer to the following document for currently supported assertions by Recorder.
+ *   https://docs.autify.com/assertions
+ *
+ *   Change the following values to fit your test case:
+ *     selector: A string of a selector to specify the element
+ *     expected: Set true if you expect the element to be checked, otherwise set false
+ *
+ * このスニペットの用途:
+ *   レコーダーで検証できないチェック可能要素 (<input type="radio"> で実装されたラジオボタンなど) が
+ *   チェックされているかどうかのアサーションを行いたい場合にご利用ください。 
+ * 
+ *   現在レコーダーでサポートされているアサーションについては、以下をご確認ください。
+ *   https://docs.autify.com/ja/assertions
+ * 
+ *   以下の値をテストケースに合うように変更してください:
+ *     selector: 対象要素を特定するセレクタの文字列
+ *     expected: チェックされていることを期待する場合は true, されていないことを期待する場合は false
+ */
+var selector = "<TODO: REPLACE SELECTOR>";
+var expected = true;
+
+/* --------- You don't need to touch below ---------------
+ * --------- ここから下は変える必要はありません ---------- */
+
 /* Locate the element
  * 要素を探す */
-var selector = "<TODO: REPLACE SELECTOR>";
 var element  = document.querySelector(selector);
-
-/* Set expected value (Set true if you expect the element to be checked, otherwise set false)
- * 期待する値を設定する (チェックされていることを期待する場合は true, されていないことを期待する場合は false を設定する)　*/
-var expected = true;
 
 /* Exit if it does not exist
  * 要素がなければ処理を中断する */
@@ -20,6 +44,6 @@ var actual = element.checked;
 /* Exit if the actual value does not match the expected value
  * 実際の値と期待する値が違う場合、処理を中断する */
 if (actual !== expected) {
-   throw new Error('Error: the actual(' + actual + ') does not match the expected(' + expected + ').');
+   throw new Error('Error: [assert checked] the actual(' + actual + ') does not match the expected(' + expected + ').');
 }
 

--- a/snippets/double-click-element.js
+++ b/snippets/double-click-element.js
@@ -1,6 +1,25 @@
+/* Usage of this snippet:
+ *   Use this snippet to fire a double-click event on an element.
+ *
+ *   Change the following value to specify the element:
+ *     selector: A string of the element selector
+ *
+ * このスニペットの用途:
+ *   要素に対してダブルクリックを発生させるのに使用します。
+ *
+ *   以下の値を対象要素に合わせて変更してください。
+ *     selector: 要素を特定するセレクタの文字列
+ */
+
+/* Specify the element selector
+ * 要素のセレクタを指定する */
+var selector = "<TODO: REPLACE SELECTOR>";
+
+/* --------- You don't need to touch below ---------------
+ * --------- ここから下は変える必要はありません ---------- */
+
 /* Locate the element
  * 要素を探す */
-var selector = "<TODO: REPLACE SELECTOR>";
 var element  = document.querySelector(selector);
 
 /* Exit if it does not exist

--- a/snippets/double-click-element.js
+++ b/snippets/double-click-element.js
@@ -11,9 +11,21 @@ if (!element) {
 
 /* Create and init a double-click event
  * ダブルクリックのイベントを生成し初期化する */
-var doubleClickEvent = document.createEvent('MouseEvents');
-doubleClickEvent.initEvent('dblclick', true, true);
-
+var event;
+if (typeof(Event) === 'function') {
+   /**
+    * For modern browser
+    * モダンブラウザの場合 
+    */
+   event = new MouseEvent("dblclick", {"bubbles":true, "cancelable":true})
+} else {
+   /** 
+    * For IE 11
+    * IE 11 の場合
+    */
+   event = document.createEvent('MouseEvents');
+   event.initEvent('dblclick', true, true);
+}
 /* Fire a double-click event
  * ダブルクリックのイベントを発火させる */
-element.dispatchEvent(doubleClickEvent);  
+element.dispatchEvent(event);  

--- a/snippets/double-click-element.js
+++ b/snippets/double-click-element.js
@@ -1,0 +1,19 @@
+/* Locate the element
+ * 要素を探す */
+var selector = "<TODO: REPLACE SELECTOR>";
+var element  = document.querySelector(selector);
+
+/* Exit if it does not exist
+ * 要素がなければ処理を中断する */
+if (!element) {
+  throw new Error('Error: cannot find the element with selector(' + selector + ').');
+}
+
+/* Create and init a double-click event
+ * ダブルクリックのイベントを生成し初期化する */
+var doubleClickEvent = document.createEvent('MouseEvents');
+doubleClickEvent.initEvent('dblclick', true, true);
+
+/* Fire a double-click event
+ * ダブルクリックのイベントを発火させる */
+element.dispatchEvent(doubleClickEvent);  

--- a/snippets/right-click-element.js
+++ b/snippets/right-click-element.js
@@ -1,6 +1,25 @@
+/* Usage of this snippet:
+ *   Use this snippet to fire a right-click event on an element.
+ *
+ *   Change the following value to specify the element:
+ *     selector: A string of the element selector
+ *
+ * このスニペットの用途:
+ *   要素に対して右クリックを発生させるのに使用します。
+ *
+ *   以下の値を対象要素に合わせて変更してください。
+ *     selector: 要素を特定するセレクタの文字列
+ */
+
+/* Specify the element selector
+ * 要素のセレクタを指定する */
+var selector = "<TODO: REPLACE SELECTOR>";
+
+/* --------- You don't need to touch below ---------------
+ * --------- ここから下は変える必要はありません ---------- */
+
 /* Locate the element
  * 要素を探す */
-var selector = "<TODO: REPLACE SELECTOR>";
 var element  = document.querySelector(selector);
 
 /* Exit if it does not exist

--- a/snippets/right-click-element.js
+++ b/snippets/right-click-element.js
@@ -11,9 +11,21 @@ if (!element) {
 
 /* Create and init a right-click (to be exact, contextmenu) event
  * 右クリック (厳密にはcontextmenu) のイベントを生成して初期化する */
-var rightClickEvent = document.createEvent('MouseEvents');
-rightClickEvent.initEvent('contextmenu', true, true);
-
+var event;
+if (typeof(Event) === 'function') {
+   /**
+    * For modern browser
+    * モダンブラウザの場合 
+    */
+   event = new MouseEvent("contextmenu", {"bubbles":true, "cancelable":true})
+} else {
+   /** 
+    * For IE 11
+    * IE 11 の場合
+    */
+   event = document.createEvent('MouseEvents');
+   event.initEvent('contextmenu', true, true);
+}
 /* Fire a right-click event
  * 右クリックのイベントを発火させる */
-element.dispatchEvent(rightClickEvent);  
+element.dispatchEvent(event);  

--- a/snippets/right-click-element.js
+++ b/snippets/right-click-element.js
@@ -1,0 +1,19 @@
+/* Locate the element
+ * 要素を探す */
+var selector = "<TODO: REPLACE SELECTOR>";
+var element  = document.querySelector(selector);
+
+/* Exit if it does not exist
+ * 要素がなければ処理を中断する */
+if (!element) {
+  throw new Error('Error: cannot find the element with selector(' + selector + ').');
+}
+
+/* Create and init a right-click (to be exact, contextmenu) event
+ * 右クリック (厳密にはcontextmenu) のイベントを生成して初期化する */
+var rightClickEvent = document.createEvent('MouseEvents');
+rightClickEvent.initEvent('contextmenu', true, true);
+
+/* Fire a right-click event
+ * 右クリックのイベントを発火させる */
+element.dispatchEvent(rightClickEvent);  


### PR DESCRIPTION
Add these three snippets to provide JS workaround for:
- Double-click
- Right-click (_contextmenu_, to be exact)
- Assert if the element is checked (since the _checked_ assertion on `<input type="radio">` is not supported yet on the recorder)