### PR TITLE
Fix to use a synchronous assertion

### DIFF
--- a/snippets/xhr-post.js
+++ b/snippets/xhr-post.js
@@ -9,13 +9,8 @@ xhr.open("POST", url, false);
 xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 xhr.send("key=value");
 
-xhr.onload = function() {
-  if (xhr.status !== 200) {
-    throw new Error("Error " + xhr.status)
-  }
-  console.log(JSON.parse(xhr.response))
-};
+if (xhr.status !== 200) {
+  throw new Error("Error " + xhr.status)
+}
 
-xhr.onerror = function() {
-  throw new Error("Error: Network Error")
-};
+console.log(JSON.parse(xhr.response))


### PR DESCRIPTION
Hi 

I found a snippet that I want to fix.
Although It set the asynchronous flag as false, errors were called in asynchronous events. This throw error cannot be detected by Autify because it detects only synchronous errors.

When this flag is set as false, `xhr.send` blocks later processes until receiving the server's response.
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#example_http_synchronous_request

Please check it. Thank you. 