### PR TITLE
Add TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # autify-javascript-snippets &middot; ![check-js-syntax](https://github.com/autifyhq/autify-javascript-snippets/workflows/check-js-syntax/badge.svg?branch=master)
 
-### Support browsers
+### Table of Contents
 
-| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>IE / Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Android Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Android Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>iOS Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/samsung-internet/samsung-internet_48x48.png" alt="Samsung" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Samsung |
-| --------- | --------- | --------- | --------- | --------- | --------- | --------- |
-| IE11, Legacy Edge, Edge | last version| last version| last version| last version| last version | last version
-
+[English]()
+[Japanese]()
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ### Table of Contents
 
-[English](toc-en.md)
-[Japanese](toc-ja.md)
+* [English](toc-en.md)
+* [Japanese](toc-ja.md)
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ### Table of Contents
 
-[English]()
-[Japanese]()
+[English](toc-en.md)
+[Japanese](toc-ja.md)
 
 ### License
 

--- a/toc-en.md
+++ b/toc-en.md
@@ -2,25 +2,25 @@
 
 File | Description
 ---|---
-./snippets/add-element-to-iframe.js |
-./snippets/add-text-to-iframe.js |
-./snippets/assert-attribute-must-be-set.js | In the case when you want to confirm an element having a specified attribute.
-./snippets/assert-attribute-must-not-be-set.js | In the case when you want to confirm an element must not to have a specified attribute.
-./snippets/assert-checked.js | Use this snippet to assert that a checkable element (such as a radio button implemented as <input type="radio">) is checked or not, in case it is not possible with Recorder.
-./snippets/assert-disabled.js |  In the case when you want to confirm a element with the attribute `disabled`.
-./snippets/assert-style.js |
-./snippets/assert-values-of-attributes.js | In the case when you want to assert a value of a specified attribute.
-./snippets/back-forward-reload.js |
-./snippets/click-element-found-by-xpath.js | This snippet can be used to click an element found by XPath.
-./snippets/click-element.js |
-./snippets/double-click-element.js | Use this snippet to fire a double-click event on an element.
-./snippets/generate-random-value.js | Use this snippet to create a random number.
-./snippets/get-text-content.js
-./snippets/get-timestamp-according-to-timezone.js | Use this snippet to generate timestamps depends on the locale on execution environment.
-./snippets/mouseover.js
-./snippets/right-click-element.js | Use this snippet to fire a right-click event on an element.
-./snippets/scroll-in-an-element | ページ全体ではなく、特定の要素の中でスクロールさせたいときにご利用ください。
-./snippets/scroll-to-element.js |
-./snippets/scroll.js
-./snippets/set-input-value.js | In the case when you want to set value to <input> element. Use this if Autify is unable to enter values in a test run for some reason. <input type="date"> is a typical element that is not supported by Autify.
-./snippets/xhr-post.js | Send POST request to HTTP URL.
+[./snippets/add-element-to-iframe.js](./snippets/add-element-to-iframe.js) |
+[./snippets/add-text-to-iframe.js](./snippets/add-text-to-iframe.js) |
+[./snippets/assert-attribute-must-be-set.js](./snippets/assert-attribute-must-be-set.js) | In the case when you want to confirm an element having a specified attribute.
+[./snippets/assert-attribute-must-not-be-set.js](./snippets/assert-attribute-must-not-be-set.js) | In the case when you want to confirm an element must not to have a specified attribute.
+[./snippets/assert-checked.js](./snippets/assert-checked.js) | Use this snippet to assert that a checkable element (such as a radio button implemented as <input type="radio">) is checked or not, in case it is not possible with Recorder.
+[./snippets/assert-disabled.js](./snippets/assert-disabled.js) |  In the case when you want to confirm a element with the attribute `disabled`.
+[./snippets/assert-style.js](./snippets/assert-style.js) |
+[./snippets/assert-values-of-attributes.js](./snippets/assert-values-of-attributes.js) | In the case when you want to assert a value of a specified attribute.
+[./snippets/back-forward-reload.js](./snippets/back-forward-reload.js) |
+[./snippets/click-element-found-by-xpath.js](./snippets/click-element-found-by-xpath.js) | This snippet can be used to click an element found by XPath.
+[./snippets/click-element.js](./snippets/click-element.js) |
+[./snippets/double-click-element.js](./snippets/double-click-element.js) | Use this snippet to fire a double-click event on an element.
+[./snippets/generate-random-value.js](./snippets/generate-random-value.js) | Use this snippet to create a random number.
+[./snippets/get-text-content.js](./snippets/get-text-content.js) |
+[./snippets/get-timestamp-according-to-timezone.js](./snippets/get-timestamp-according-to-timezone.js) | Use this snippet to generate timestamps depends on the locale on execution environment.
+[./snippets/mouseover.js](./snippets/mouseover.js) |
+[./snippets/right-click-element.js](./snippets/right-click-element.js) | Use this snippet to fire a right-click event on an element.
+[./snippets/scroll-in-an-element](./snippets/scroll-in-an-element) | ページ全体ではなく、特定の要素の中でスクロールさせたいときにご利用ください。
+[./snippets/scroll-to-element.js](./snippets/scroll-to-element.js) |
+[./snippets/scroll.js](./snippets/scroll.js) |
+[./snippets/set-input-value.js](./snippets/set-input-value.js) | In the case when you want to set value to `<input>` element. Use this if Autify is unable to enter values in a test run for some reason. `<input type="date">` is a typical element that is not supported by Autify.
+[./snippets/xhr-post.js](./snippets/xhr-post.js) | Send POST request to HTTP URL.

--- a/toc-en.md
+++ b/toc-en.md
@@ -1,0 +1,26 @@
+# 目次
+
+File | Description
+---|---
+./snippets/add-element-to-iframe.js |
+./snippets/add-text-to-iframe.js |
+./snippets/assert-attribute-must-be-set.js | In the case when you want to confirm an element having a specified attribute.
+./snippets/assert-attribute-must-not-be-set.js | In the case when you want to confirm an element must not to have a specified attribute.
+./snippets/assert-checked.js | Use this snippet to assert that a checkable element (such as a radio button implemented as <input type="radio">) is checked or not, in case it is not possible with Recorder.
+./snippets/assert-disabled.js |  In the case when you want to confirm a element with the attribute `disabled`.
+./snippets/assert-style.js |
+./snippets/assert-values-of-attributes.js | In the case when you want to assert a value of a specified attribute.
+./snippets/back-forward-reload.js |
+./snippets/click-element-found-by-xpath.js | This snippet can be used to click an element found by XPath.
+./snippets/click-element.js |
+./snippets/double-click-element.js | Use this snippet to fire a double-click event on an element.
+./snippets/generate-random-value.js | Use this snippet to create a random number.
+./snippets/get-text-content.js
+./snippets/get-timestamp-according-to-timezone.js | Use this snippet to generate timestamps depends on the locale on execution environment.
+./snippets/mouseover.js
+./snippets/right-click-element.js | Use this snippet to fire a right-click event on an element.
+./snippets/scroll-in-an-element | ページ全体ではなく、特定の要素の中でスクロールさせたいときにご利用ください。
+./snippets/scroll-to-element.js |
+./snippets/scroll.js
+./snippets/set-input-value.js | In the case when you want to set value to <input> element. Use this if Autify is unable to enter values in a test run for some reason. <input type="date"> is a typical element that is not supported by Autify.
+./snippets/xhr-post.js | Send POST request to HTTP URL.

--- a/toc-ja.md
+++ b/toc-ja.md
@@ -1,0 +1,26 @@
+# 目次
+
+File | Description
+---|---
+./snippets/add-element-to-iframe.js |
+./snippets/add-text-to-iframe.js |
+./snippets/assert-attribute-must-be-set.js | 要素が特定の属性を持っていることを確認をしたいときにご利用ください。
+./snippets/assert-attribute-must-not-be-set.js | 要素が特定の属性を持っていないことを確認をしたいときにご利用ください。
+./snippets/assert-checked.js | レコーダーで検証できないチェック可能要素 (<input type="radio"> で実装されたラジオボタンなど) がチェックされているかどうかのアサーションを行いたい場合にご利用ください。
+./snippets/assert-disabled.js |  `disabled` 属性の存在を確認したい（ボタンなどが非活性になっていることを確認したい）ときに使用します。
+./snippets/assert-style.js |
+./snippets/assert-values-of-attributes.js | 特定の属性の値を検証したいときにご利用ください。
+./snippets/back-forward-reload.js |
+./snippets/click-element-found-by-xpath.js | XPathを指定して見つかった要素をクリックします。
+./snippets/click-element.js |
+./snippets/double-click-element.js | 要素に対してダブルクリックを発生させるのに使用します。
+./snippets/generate-random-value.js | 乱数を生成したいときにご利用ください。
+./snippets/get-text-content.js
+./snippets/get-timestamp-according-to-timezone.js | テスト実行時の環境に合わせたタイムスタンプを作成するために使います。
+./snippets/mouseover.js
+./snippets/right-click-element.js | 要素に対して右クリックを発生させるのに使用します。
+./snippets/scroll-in-an-element | ページ全体ではなく、特定の要素の中でスクロールさせたいときにご利用ください。
+./snippets/scroll-to-element.js |
+./snippets/scroll.js
+./snippets/set-input-value.js | <input> 要素に対して値を設定します。何らかの理由により、Autify のテスト実行で値の入力ができないときにご利用ください。
+./snippets/xhr-post.js | HTTP URLに対してPOSTリクエストを送ります。

--- a/toc-ja.md
+++ b/toc-ja.md
@@ -2,25 +2,25 @@
 
 File | Description
 ---|---
-./snippets/add-element-to-iframe.js |
-./snippets/add-text-to-iframe.js |
-./snippets/assert-attribute-must-be-set.js | 要素が特定の属性を持っていることを確認をしたいときにご利用ください。
-./snippets/assert-attribute-must-not-be-set.js | 要素が特定の属性を持っていないことを確認をしたいときにご利用ください。
-./snippets/assert-checked.js | レコーダーで検証できないチェック可能要素 (<input type="radio"> で実装されたラジオボタンなど) がチェックされているかどうかのアサーションを行いたい場合にご利用ください。
-./snippets/assert-disabled.js |  `disabled` 属性の存在を確認したい（ボタンなどが非活性になっていることを確認したい）ときに使用します。
-./snippets/assert-style.js |
-./snippets/assert-values-of-attributes.js | 特定の属性の値を検証したいときにご利用ください。
-./snippets/back-forward-reload.js |
-./snippets/click-element-found-by-xpath.js | XPathを指定して見つかった要素をクリックします。
-./snippets/click-element.js |
-./snippets/double-click-element.js | 要素に対してダブルクリックを発生させるのに使用します。
-./snippets/generate-random-value.js | 乱数を生成したいときにご利用ください。
-./snippets/get-text-content.js
-./snippets/get-timestamp-according-to-timezone.js | テスト実行時の環境に合わせたタイムスタンプを作成するために使います。
-./snippets/mouseover.js
-./snippets/right-click-element.js | 要素に対して右クリックを発生させるのに使用します。
-./snippets/scroll-in-an-element | ページ全体ではなく、特定の要素の中でスクロールさせたいときにご利用ください。
-./snippets/scroll-to-element.js |
-./snippets/scroll.js
-./snippets/set-input-value.js | <input> 要素に対して値を設定します。何らかの理由により、Autify のテスト実行で値の入力ができないときにご利用ください。
-./snippets/xhr-post.js | HTTP URLに対してPOSTリクエストを送ります。
+[./snippets/add-element-to-iframe.js](./snippets/add-element-to-iframe.js) |
+[./snippets/add-text-to-iframe.js](./snippets/add-text-to-iframe.js) |
+[./snippets/assert-attribute-must-be-set.js](./snippets/assert-attribute-must-be-set.js) | 要素が特定の属性を持っていることを確認をしたいときにご利用ください。
+[./snippets/assert-attribute-must-not-be-set.js](./snippets/assert-attribute-must-not-be-set.js) | 要素が特定の属性を持っていないことを確認をしたいときにご利用ください。
+[./snippets/assert-checked.js](./snippets/assert-checked.js) | レコーダーで検証できないチェック可能要素 (<input type="radio"> で実装されたラジオボタンなど) がチェックされているかどうかのアサーションを行いたい場合にご利用ください。
+[./snippets/assert-disabled.js](./snippets/assert-disabled.js) |  `disabled` 属性の存在を確認したい（ボタンなどが非活性になっていることを確認したい）ときに使用します。
+[./snippets/assert-style.js](./snippets/assert-style.js) |
+[./snippets/assert-values-of-attributes.js](./snippets/assert-values-of-attributes.js) | 特定の属性の値を検証したいときにご利用ください。
+[./snippets/back-forward-reload.js](./snippets/back-forward-reload.js) |
+[./snippets/click-element-found-by-xpath.js](./snippets/click-element-found-by-xpath.js) | XPathを指定して見つかった要素をクリックします。
+[./snippets/click-element.js](./snippets/click-element.js) |
+[./snippets/double-click-element.js](./snippets/double-click-element.js) | 要素に対してダブルクリックを発生させるのに使用します。
+[./snippets/generate-random-value.js](./snippets/generate-random-value.js) | 乱数を生成したいときにご利用ください。
+[./snippets/get-text-content.js](./snippets/get-text-content.js) |
+[./snippets/get-timestamp-according-to-timezone.js](./snippets/get-timestamp-according-to-timezone.js) | テスト実行時の環境に合わせたタイムスタンプを作成するために使います。
+[./snippets/mouseover.js](./snippets/mouseover.js) |
+[./snippets/right-click-element.js](./snippets/right-click-element.js) | 要素に対して右クリックを発生させるのに使用します。
+[./snippets/scroll-in-an-element](./snippets/scroll-in-an-element) | ページ全体ではなく、特定の要素の中でスクロールさせたいときにご利用ください。
+[./snippets/scroll-to-element.js](./snippets/scroll-to-element.js) |
+[./snippets/scroll.js](./snippets/scroll.js) |
+[./snippets/set-input-value.js](./snippets/set-input-value.js) | `<input>` 要素に対して値を設定します。何らかの理由により、Autify のテスト実行で値の入力ができないときにご利用ください。
+[./snippets/xhr-post.js](./snippets/xhr-post.js) | HTTP URLに対してPOSTリクエストを送ります。


### PR DESCRIPTION
Currently, there is no "Table of contents" in this repository. To see the use case of each snippet, we should open each of them one by one. I extracted the summary of the "How to use" section and create a simple ToC.

Also, I removed the "supported browser" section. Once we have automated tests for both snippets, we could revive the section again.