### PR TITLE
Make input value snippet compatible with react

### DIFF
--- a/snippets/set-input-value.js
+++ b/snippets/set-input-value.js
@@ -47,4 +47,15 @@ if (!element) {
  * 値を入力する
  */
 
-element.value = setValue;
+changeValue(element, setValue);
+
+function changeValue(input, value) {
+  var nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value"
+  ).set;
+  nativeInputValueSetter.call(input, value);
+
+  var inputEvent = new Event("input", { bubbles: true });
+  input.dispatchEvent(inputEvent);
+}


### PR DESCRIPTION
Regarding [this article](https://autify.zendesk.com/hc/ja/articles/4412627830553-%E6%97%A5%E4%BB%98%E5%85%A5%E5%8A%9B%E3%81%AE%E3%82%B9%E3%83%86%E3%83%83%E3%83%97%E3%81%A7%E3%83%86%E3%82%B9%E3%83%88%E3%81%8C%E5%A4%B1%E6%95%97%E3%81%97%E3%81%BE%E3%81%99-%E5%AF%BE%E5%87%A6%E6%96%B9%E6%B3%95%E3%81%AF%E3%81%82%E3%82%8A%E3%81%BE%E3%81%99%E3%81%8B-), date input could not be set by just updating the `value` property of the element when the target website uses React. The article refers to the workaround of it but snippet doesn't use it.
This PR will update the way to input. It's a more generic and stable way to the most input element.