### PR TITLE
Remove links to iframe snippets

### DIFF
--- a/toc-en.md
+++ b/toc-en.md
@@ -2,8 +2,6 @@
 
 File | Description
 ---|---
-[./snippets/add-element-to-iframe.js](./snippets/add-element-to-iframe.js) | Add an element inside iframe
-[./snippets/add-text-to-iframe.js](./snippets/add-text-to-iframe.js) | Add text inside iframe
 [./snippets/assert-attribute-must-be-set.js](./snippets/assert-attribute-must-be-set.js) | Assert that an element has a specified attribute
 [./snippets/assert-attribute-must-not-be-set.js](./snippets/assert-attribute-must-not-be-set.js) | Assert that an element does not have a specified attribute
 [./snippets/assert-checked.js](./snippets/assert-checked.js) | Assert that a checkable element (such as a radio button implemented as `<input type="radio">`) is checked or not, in case it is not possible with Recorder

--- a/toc-ja.md
+++ b/toc-ja.md
@@ -2,8 +2,6 @@
 
 File | Description
 ---|---
-[./snippets/add-element-to-iframe.js](./snippets/add-element-to-iframe.js) | iframeに要素を追加したいときにご利用ください。
-[./snippets/add-text-to-iframe.js](./snippets/add-text-to-iframe.js) | iframeにテキストを追加したいときにご利用ください。
 [./snippets/assert-attribute-must-be-set.js](./snippets/assert-attribute-must-be-set.js) | 要素が特定の属性を持っていることを確認をしたいときにご利用ください。
 [./snippets/assert-attribute-must-not-be-set.js](./snippets/assert-attribute-must-not-be-set.js) | 要素が特定の属性を持っていないことを確認をしたいときにご利用ください。
 [./snippets/assert-checked.js](./snippets/assert-checked.js) | レコーダーで検証できないチェック可能要素 (`<input type="radio">` で実装されたラジオボタンなど) がチェックされているかどうかのアサーションを行いたい場合にご利用ください。


### PR DESCRIPTION
As we've removed iframe snippets in the PR https://github.com/autifyhq/autify-javascript-snippets/pull/25, I'm removing the links in ToC as well