### PR TITLE
Add reading_clipboard pages

### DIFF
--- a/content/en/snippets/others/reading_clipboard.md
+++ b/content/en/snippets/others/reading_clipboard.md
@@ -1,0 +1,31 @@
+---
+title: "Reading clipboard value"
+weight: 10
+ie_support: true
+---
+
+Use this snippet when you want to read the value of clipboard if it is copied by `document.execCommand("copy")` in the previous steps.
+
+### Usage
+
+You need a pair of JavaScript steps in your scenario:
+
+1. Adding an event listener for `copy` event which stores the data to `localStorage`
+2. Getting the data from `localStorage`
+
+The step 1 should be inserted **before the click step**, then you can read the data after the click step.
+
+```js
+// Step 1
+document.addEventListener('copy', function(event) {
+  var data = document.getSelection().toString();
+  localStorage.setItem('clipboard', data);
+});
+
+// Step 2
+return localStorage.getItem('clipboard');
+```
+
+### Caveat
+
+If your website uses `navigation.clipboard.write*` API to copy the value to clipboard, this approach doesn't work because it supposed to send `clipboardchange` event but Chromium hasn't implemented the event yet as of March 2022.

--- a/content/ja/snippets/others/reading_clipboard.md
+++ b/content/ja/snippets/others/reading_clipboard.md
@@ -1,0 +1,31 @@
+---
+title: "クリップボードの値を読み出す"
+weight: 10
+ie_support: true
+---
+
+このスニペットを使うと、前のステップで`document.execCommand("copy")`を使ってクリップボードにコピーされた値を読みだすことができます。
+
+### 利用方法
+
+2つのペアになったJavaScript ステップをシナリオに追加する必要があります。
+
+1. データを`localStorage`に保存するリスナーを、`copy`イベントのイベントリスナーに追加するステップ
+2. `localStorage`からデータを読み出すステップ
+
+ステップ1は**クリックするステップの前に**挿入する必要があります。そうすることで、クリックするステップの後でデータを読み出すことができるようになります。
+
+```js
+// Step 1
+document.addEventListener('copy', function(event) {
+  var data = document.getSelection().toString();
+  localStorage.setItem('clipboard', data);
+});
+
+// Step 2
+return localStorage.getItem('clipboard');
+```
+
+### 注意点
+
+もしサイトが`navigation.clipboard.write*` API を使ってクリップボードにコピーしている場合、このアプローチはうまく動きません。このAPIは`clipboardchange`というイベントを発行することになっているのですが、2022年3月現在Chromiumではこのイベントがまだ実装されていません。


### PR DESCRIPTION
Adding new snippets for the customers who want to read the data from clipboard.

### Testings
`npm run test` succeeded.

Note: I needed to combine two snippets into one code block due to the test logic.