### PR TITLE
Update reading_clipboard to fix on Firefox and IE

### DIFF
--- a/content/en/snippets/others/reading_clipboard.md
+++ b/content/en/snippets/others/reading_clipboard.md
@@ -6,6 +6,8 @@ ie_support: true
 
 Use this snippet when you want to read the value of clipboard if it is copied by `document.execCommand("copy")` in the previous steps.
 
+Note: This snippet assumes the copied data is text.
+
 ### Usage
 
 You need a pair of JavaScript steps in your scenario:
@@ -18,8 +20,11 @@ The step 1 should be inserted **before the click step**, then you can read the d
 ```js
 // Step 1
 document.addEventListener('copy', function(event) {
-  var data = document.getSelection().toString();
-  localStorage.setItem('clipboard', data);
+  var active = document.activeElement;
+  if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+    var data = active.value.substring(active.selectionStart, active.selectionEnd);
+    localStorage.setItem('clipboard', data);
+  }
 });
 
 // Step 2
@@ -28,4 +33,10 @@ return localStorage.getItem('clipboard');
 
 ### Caveat
 
-If your website uses `navigation.clipboard.write*` API to copy the value to clipboard, this approach doesn't work because it supposed to send `clipboardchange` event but Chromium hasn't implemented the event yet as of March 2022.
+#### iOS Safari doesn't work with `document.execCommand("copy")` with Autify
+
+Due to technical limitation, Autify can't properly trigger `document.execCommand("copy")` only on iOS Safari environment yet.  Therefore, this snippet (or any other workaround) won't work with iOS Safari as of March 2022.
+
+#### Doesn't support `navigation.clipboard.writeText()` API
+
+If your website uses `navigation.clipboard.writeText()` API to copy the value to clipboard, this approach doesn't work because it supposed to send `clipboardchange` event but Chromium hasn't implemented the event yet as of March 2022.

--- a/content/ja/snippets/others/reading_clipboard.md
+++ b/content/ja/snippets/others/reading_clipboard.md
@@ -6,6 +6,7 @@ ie_support: true
 
 このスニペットを使うと、前のステップで`document.execCommand("copy")`を使ってクリップボードにコピーされた値を読みだすことができます。
 
+注: このスニペットはコピーされたデータがテキストであると仮定しています。
 ### 利用方法
 
 2つのペアになったJavaScript ステップをシナリオに追加する必要があります。
@@ -18,8 +19,11 @@ ie_support: true
 ```js
 // Step 1
 document.addEventListener('copy', function(event) {
-  var data = document.getSelection().toString();
-  localStorage.setItem('clipboard', data);
+  var active = document.activeElement;
+  if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+    var data = active.value.substring(active.selectionStart, active.selectionEnd);
+    localStorage.setItem('clipboard', data);
+  }
 });
 
 // Step 2
@@ -28,4 +32,10 @@ return localStorage.getItem('clipboard');
 
 ### 注意点
 
-もしサイトが`navigation.clipboard.write*` API を使ってクリップボードにコピーしている場合、このアプローチはうまく動きません。このAPIは`clipboardchange`というイベントを発行することになっているのですが、2022年3月現在Chromiumではこのイベントがまだ実装されていません。
+#### Autify ではiOS Safari の`document.execCommand("copy")` は機能しません
+
+技術的制約により、Autify では`document.execCommand("copy")` がiOS Safari の環境上でのみうまく発動しません。そのため、このスニペット(および他の回避策)はiOS Safari 上では機能しません。(2022年3月現在)
+
+#### `navigation.clipboard.writeText()` API では使えません
+
+もしサイトが`navigation.clipboard.writeText()` API を使ってクリップボードにコピーしている場合、このアプローチはうまく動きません。このAPIは`clipboardchange`というイベントを発行することになっているのですが、2022年3月現在Chromiumではこのイベントがまだ実装されていません。


### PR DESCRIPTION
The previous snippet doesn't work with Firefox nor IE.
The snippet is fixed by this change.

Also, more notes and caveats are added.