### PR TITLE
Update link to help center

### DIFF
--- a/content/en/snippets/assertions/assert_checked.md
+++ b/content/en/snippets/assertions/assert_checked.md
@@ -8,7 +8,7 @@ Use this snippet to assert that a checkable element (such as a radio button impl
 
 Refer to the following document for currently supported assertions by Recorder.
 
-https://autify.zendesk.com/hc/en-us/articles/900001652023
+https://help.autify.com/docs/list-of-assertions
 
 Change the following values to fit your test case:
 

--- a/content/ja/snippets/assertions/assert_checked.md
+++ b/content/ja/snippets/assertions/assert_checked.md
@@ -8,7 +8,7 @@ ie_support: true
 
 現在レコーダーでサポートされているアサーションについては、以下をご確認ください。
 
-https://autify.zendesk.com/hc/ja/articles/900001652023
+https://help.autify.com/docs/ja/list-of-assertions?highlight=%E3%82%A2%E3%82%B5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E4%B8%80%E8%A6%A7
 
 以下の値をテストケースに合うように変更してください:
 

--- a/content/ja/snippets/assertions/assert_checked.md
+++ b/content/ja/snippets/assertions/assert_checked.md
@@ -8,7 +8,7 @@ ie_support: true
 
 現在レコーダーでサポートされているアサーションについては、以下をご確認ください。
 
-https://help.autify.com/docs/ja/list-of-assertions?highlight=%E3%82%A2%E3%82%B5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E4%B8%80%E8%A6%A7
+https://help.autify.com/docs/ja/list-of-assertions
 
 以下の値をテストケースに合うように変更してください:
 

--- a/snippets/assert-checked.js
+++ b/snippets/assert-checked.js
@@ -4,7 +4,7 @@
  *   is checked or not, in case it is not possible with Recorder.
  * 
  *   Refer to the following document for currently supported assertions by Recorder.
- *   https://autify.zendesk.com/hc/en-us/articles/900001652023
+ *   https://help.autify.com/docs/list-of-assertions
  *
  *   Change the following values to fit your test case:
  *     selector: A string of a selector to specify the element

--- a/snippets/assert-checked.js
+++ b/snippets/assert-checked.js
@@ -15,7 +15,7 @@
  *   チェックされているかどうかのアサーションを行いたい場合にご利用ください。 
  * 
  *   現在レコーダーでサポートされているアサーションについては、以下をご確認ください。
- *   https://autify.zendesk.com/hc/ja/articles/900001652023
+ *   https://help.autify.com/docs/ja/list-of-assertions
  * 
  *   以下の値をテストケースに合うように変更してください:
  *     selector: 対象要素を特定するセレクタの文字列


### PR DESCRIPTION
This PR will change the links to Help Center from old ones to new ones.

EN
- Old: https://autify.zendesk.com/hc/articles/900001652023
- New: https://help.autify.com/docs/list-of-assertions

JA
- Old: https://autify.zendesk.com/hc/ja/articles/900001652023
- New: https://help.autify.com/docs/ja/list-of-assertions