### PR TITLE
Fix set input value

### DIFF
--- a/content/en/snippets/values/set_value.md
+++ b/content/en/snippets/values/set_value.md
@@ -60,6 +60,6 @@ function changeValue(input, value) {
     inputEvent = document.createEvent("Event");
     inputEvent.initEvent("input", true, true);
   }
-  element.dispatchEvent(inputEvent);
+  input.dispatchEvent(inputEvent);
 }
 ```

--- a/content/ja/snippets/values/set_value.md
+++ b/content/ja/snippets/values/set_value.md
@@ -60,6 +60,6 @@ function changeValue(input, value) {
     inputEvent = document.createEvent("Event");
     inputEvent.initEvent("input", true, true);
   }
-  element.dispatchEvent(inputEvent);
+  input.dispatchEvent(inputEvent);
 }
 ```


### PR DESCRIPTION
`element` in the `changeValue` function is modified to `input`.

The scope of `element` in the `changeValue` function is outside function.
No problem for use in the JS step, but for example if you use this function for inputting multiple input elements on the console will result in unintended behavior.