### PR TITLE
Add a snippet to import a JavaScript library

### DIFF
--- a/content/en/snippets/others/import_js.md
+++ b/content/en/snippets/others/import_js.md
@@ -1,0 +1,35 @@
+---
+title: "Import a JavaScript library"
+weight: 30
+ie_support: false
+---
+
+Import a JavaScript library. The following example imports jQuery from CDN.
+It loads JavaScript by creating a `<script>` element and adding it to the `<head>` element.
+
+(Caveat) When you use a third-party library, please do it at your own risk.
+
+```js
+const script = document.createElement('script');
+/* Specify the URL of a JavaScript library */
+script.src = "https://code.jquery.com/jquery-3.6.0.min.js";
+
+/* You don't need to touch below */
+return new Promise((resolve, reject) => {
+  script.onerror = () => {
+    reject(new Error("Failed to load script"))
+  }
+  script.onload = () => {
+    resolve()
+  }
+
+  document.head.appendChild(script);
+})
+```
+
+You can use the functions of jQuery in following JS steps.
+
+```js
+// Example usage of jQuery
+return $("h1").text();
+```

--- a/content/en/snippets/others/import_js.md
+++ b/content/en/snippets/others/import_js.md
@@ -27,7 +27,7 @@ return new Promise((resolve, reject) => {
 })
 ```
 
-You can use the functions of jQuery in following JS steps.
+You can use the functions of jQuery in subsequent JS steps.
 
 ```js
 // Example usage of jQuery

--- a/content/en/snippets/others/import_js.md
+++ b/content/en/snippets/others/import_js.md
@@ -7,7 +7,7 @@ ie_support: false
 Import a JavaScript library. The following example imports jQuery from CDN.
 It loads JavaScript by creating a `<script>` element and adding it to the `<head>` element.
 
-(Caveat) When you use a third-party library, please do it at your own risk.
+(Caveat) When you use a third-party library, please do it at your own risk. If you should use a malicious library, your web site whould be exposed to risks to execute arbitary codes.
 
 ```js
 const script = document.createElement('script');

--- a/content/en/snippets/others/import_js.md
+++ b/content/en/snippets/others/import_js.md
@@ -7,7 +7,7 @@ ie_support: false
 Import a JavaScript library. The following example imports jQuery from CDN.
 It loads JavaScript by creating a `<script>` element and adding it to the `<head>` element.
 
-(Caveat) When you use a third-party library, please do it at your own risk. If you should use a malicious library, your web site whould be exposed to risks to execute arbitary codes.
+(Caveat) When you use a third-party library, please do it at your own risk. If you should use a malicious library, your web site would be exposed to risks to execute arbitary codes.
 
 ```js
 const script = document.createElement('script');

--- a/content/ja/snippets/others/import_js.md
+++ b/content/ja/snippets/others/import_js.md
@@ -1,0 +1,35 @@
+---
+title: "Import a JavaScript library"
+weight: 30
+ie_support: false
+---
+
+JavaScript ライブラリを読み込みます。以下の例では jQuery を CDN から読み込んでいます。
+`<script>` 要素を生成して `<head>` 要素に追加することで JavaScript を読み込めます。
+
+（注意）サードパーティライブラリのご利用は自己責任でお願いします
+
+```js
+const script = document.createElement('script');
+/* ライブラリの URL を指定する */
+script.src = "https://code.jquery.com/jquery-3.6.0.min.js";
+
+/* ここから下は変える必要はありません */
+return new Promise((resolve, reject) => {
+  script.onerror = () => {
+    reject(new Error("Failed to load script"))
+  }
+  script.onload = () => {
+    resolve()
+  }
+
+  document.head.appendChild(script);
+})
+```
+
+後続の JS ステップで jQuery の関数が使えるようになります。
+
+```js
+// jQuery の使用例
+return $("h1").text();
+```

--- a/content/ja/snippets/others/import_js.md
+++ b/content/ja/snippets/others/import_js.md
@@ -7,7 +7,7 @@ ie_support: false
 JavaScript ライブラリを読み込みます。以下の例では jQuery を CDN から読み込んでいます。
 `<script>` 要素を生成して `<head>` 要素に追加することで JavaScript を読み込めます。
 
-（注意）サードパーティライブラリのご利用は自己責任でお願いします。
+（注意）サードパーティライブラリのご利用は自己責任でお願いします。悪意のあるライブラリを使用すると任意の JavaScript コードをサイト内で実行される危険性がありますのでご注意ください。
 
 ```js
 const script = document.createElement('script');

--- a/content/ja/snippets/others/import_js.md
+++ b/content/ja/snippets/others/import_js.md
@@ -1,5 +1,5 @@
 ---
-title: "Import a JavaScript library"
+title: "JavaScript ライブラリを読み込む"
 weight: 30
 ie_support: false
 ---

--- a/content/ja/snippets/others/import_js.md
+++ b/content/ja/snippets/others/import_js.md
@@ -7,7 +7,7 @@ ie_support: false
 JavaScript ライブラリを読み込みます。以下の例では jQuery を CDN から読み込んでいます。
 `<script>` 要素を生成して `<head>` 要素に追加することで JavaScript を読み込めます。
 
-（注意）サードパーティライブラリのご利用は自己責任でお願いします
+（注意）サードパーティライブラリのご利用は自己責任でお願いします。
 
 ```js
 const script = document.createElement('script');

--- a/test/contents.test.js
+++ b/test/contents.test.js
@@ -14,8 +14,8 @@ const __dirname = new URL(".", import.meta.url).pathname;
 const contentDir = (lang) =>
   path.resolve(__dirname, "../content", lang, "snippets");
 
-const jsCodeBlockPattern = /```js(.+)```/s;
-const frontMatterPattern = /---\n(.+)\n---/s;
+const jsCodeBlockPattern = /```js(.+?)```/s;
+const frontMatterPattern = /---\n(.+?)\n---/s;
 
 describe("content/", () => {
   const langs = ["en/", "ja/"];


### PR DESCRIPTION
Add snippet pages to import a JavaScript library, which would be helpful when you want to import and load libraries: for example, utility libraries like [day.js](https://day.js.org/) or a SDK of something.

Note: it does not support IE11 because it does not support [Promise objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).