### PR TITLE
Localize the description for the Delay snippet

### DIFF
--- a/content/ja/snippets/others/delay.md
+++ b/content/ja/snippets/others/delay.md
@@ -1,5 +1,5 @@
 ---
-title: "Delay (with await)"
+title: "遅延（awaitを利用）"
 weight: 10
 ie_support: false
 ---


### PR DESCRIPTION
Changed the description in Japanese: `Delay (with await)` -> `遅延（awaitを利用）`