### PR TITLE
updated find_by_innertext example (now it uses XPath)

### DIFF
--- a/content/en/snippets/others/find_by_innertext.md
+++ b/content/en/snippets/others/find_by_innertext.md
@@ -4,25 +4,39 @@ weight: 10
 ie_support: false
 ---
 
-Find an element that contains the specified inner text.
+Find an element that contains the specified inner text (exact match).
+If there are multiple elements that have the same text, the first matched element will be returned.
 
 ```js
-const targetText = ""; //TODO: Put the text you want to look for.
-const tagName = ""; //TODO: Put the tag name that should contain the target text.
+const targetText = ""; //TODO: Specify a text that you want to find.
+const targetTagName = ""; //TODO: Specify a tag name that contains the text.
 
-const candidates = document.getElementsByTagName(tagName);
-const filtered = Array.from(candidates).filter((el) => el.innerText === targetText); // Exact match.
+/*
+* By default, this JS snippet finds the element by an exact match.
+* If you want to use a partial match, replace the xpath expression with following.
+* //${targetTagName}[contains(text(), "${targetText}")]
+*/
+const xpath = `//${targetTagName}[text()="${targetText}"]`;
 
-const count = filtered.length;
-if (!count) {
-  throw new Error(`Element contains text "${targetText}" not found`);
+function getElementByXpath(xp) {
+  return document.evaluate(
+    xp,
+    document,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null
+  ).singleNodeValue;
 }
-if (count > 1) {
-  console.log(`${count} elements found. Taking the first element in the list as a target.`);
+
+const element = getElementByXpath(xpath);
+
+if (!element) {
+  throw new Error(`Error: Element not found (${xpath})`);
 }
 
-const targetElement = filtered[0];
-
-// Do something to the target element, for example,
-targetElement.click();
+/*
+* Write some interactions with the element.
+* Use the click() method, put assertions, just return it, etc. 
+*/
+element.click();
 ```

--- a/content/en/snippets/others/find_by_innertext.md
+++ b/content/en/snippets/others/find_by_innertext.md
@@ -7,6 +7,8 @@ ie_support: false
 Find an element that contains the specified inner text (exact match).
 If there are multiple elements that have the same text, the first matched element will be returned.
 
+## XPath example
+
 ```js
 const targetText = ""; //TODO: Specify a text that you want to find.
 const targetTagName = ""; //TODO: Specify a tag name that contains the text.
@@ -39,4 +41,35 @@ if (!element) {
 * Use the click() method, put assertions, just return it, etc. 
 */
 element.click();
+```
+
+## CSS selector example
+
+```js
+const targetText = ""; //TODO: Specify a text that you want to find.
+const tagName = ""; //TODO: Specify a tag name that contains the text.
+
+/*
+* By default, this JS snippet finds the element by an exact match.
+* If you want to use a partial match, replace the filtering function with following.
+* (el) => el.innerText.includes(targetText)
+*/
+const candidates = document.getElementsByTagName(tagName);
+const filtered = Array.from(candidates).filter((el) => el.innerText === targetText);
+
+const count = filtered.length;
+if (!count) {
+  throw new Error(`${tagName.toUpperCase()} element contains text "${targetText}" not found`);
+}
+if (count > 1) {
+  console.log(`${count} elements found. Taking the first element in the list as a target.`);
+}
+
+const targetElement = filtered[0];
+
+/*
+* Write some interactions with the element.
+* Use the click() method, put assertions, just return it, etc. 
+*/
+targetElement.click();
 ```

--- a/content/ja/snippets/others/find_by_innertext.md
+++ b/content/ja/snippets/others/find_by_innertext.md
@@ -4,25 +4,39 @@ weight: 10
 ie_support: false
 ---
 
-要素のテキストを指定して探索を行います。
+指定されたテキストを含む要素を探します(完全一致です)。
+複数の要素がマッチする場合、最初に見つかったものが使われます。
 
 ```js
-const targetText = ""; //TODO: 探したいテキストを指定してください
-const tagName = ""; //TODO: そのテキストを含んでいる要素の、タグ名を指定してください
+const targetText = ""; //TODO: 探したいテキストを指定してください。
+const targetTagName = ""; //TODO: そのテキストを含むタグの名前を指定してください。
 
-const candidates = document.getElementsByTagName(tagName);
-const filtered = Array.from(candidates).filter((el) => el.innerText === targetText); // 完全一致です
+/*
+* このスニペットは、テキストの完全一致で要素を探索します。
+* 部分一致で探索を行いたい場合は、 XPath を以下のように書き換えてください。
+* //${targetTagName}[contains(text(), "${targetText}")]
+*/
+const xpath = `//${targetTagName}[text()="${targetText}"]`;
 
-const count = filtered.length;
-if (!count) {
-  throw new Error(`Element contains text "${targetText}" not found`);
+function getElementByXpath(xp) {
+  return document.evaluate(
+    xp,
+    document,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null
+  ).singleNodeValue;
 }
-if (count > 1) {
-  console.log(`${count} elements found. Taking the first element in the list as a target.`);
+
+const element = getElementByXpath(xpath);
+
+if (!element) {
+  throw new Error(`Error: Element not found (${xpath})`);
 }
 
-const targetElement = filtered[0];
-
-// 対象の要素に対して操作を行います。例えば…
-targetElement.click();
+/*
+* 要素に対して行いたい操作を記述してください。
+* click() メソッドを使う、アサーションを行う、そのまま要素を返す、など。
+*/
+element.click();
 ```

--- a/content/ja/snippets/others/find_by_innertext.md
+++ b/content/ja/snippets/others/find_by_innertext.md
@@ -7,6 +7,8 @@ ie_support: false
 指定されたテキストを含む要素を探します(完全一致です)。
 複数の要素がマッチする場合、最初に見つかったものが使われます。
 
+## XPath を使用した例
+
 ```js
 const targetText = ""; //TODO: 探したいテキストを指定してください。
 const targetTagName = ""; //TODO: そのテキストを含むタグの名前を指定してください。
@@ -39,4 +41,34 @@ if (!element) {
 * click() メソッドを使う、アサーションを行う、そのまま要素を返す、など。
 */
 element.click();
+```
+## CSS セレクターを使用した例
+
+```js
+const targetText = ""; //TODO: 探したいテキストを指定してください。
+const tagName = ""; //TODO: そのテキストを含むタグの名前を指定してください。
+
+/*
+* このスニペットは、テキストの完全一致で要素を探索します。
+* 部分一致で探索を行いたい場合は、 filter 用の関数を以下のように書き換えてください。
+* (el) => el.innerText.includes(targetText)
+*/
+const candidates = document.getElementsByTagName(tagName);
+const filtered = Array.from(candidates).filter((el) => el.innerText === targetText);
+
+const count = filtered.length;
+if (!count) {
+  throw new Error(`${tagName.toUpperCase()} element contains text "${targetText}" not found`);
+}
+if (count > 1) {
+  console.log(`${count} elements found. Taking the first element in the list as a target.`);
+}
+
+const targetElement = filtered[0];
+
+/*
+* 要素に対して行いたい操作を記述してください。
+* click() メソッドを使う、アサーションを行う、そのまま要素を返す、など。
+*/
+targetElement.click();
 ```


### PR DESCRIPTION
Updated an existing snippet.
From CSS Selector to XPath.
I believe it becomes more intuitive this way.