### PR TITLE
fix xpath to get tr element and search with multiple texts

### DIFF
--- a/content/en/snippets/others/search_in_table_and_operate_specific_column.md
+++ b/content/en/snippets/others/search_in_table_and_operate_specific_column.md
@@ -5,14 +5,16 @@ ie_support: false
 ---
 
 Search for a text in a table and get the element of a specific column in the row found by the search.
+Search with multiple texts are also possible, and lines with all specified texts will be targeted.
 Then do something like "click" or "get innerText" on the element.
 If there are multiple matches, the first matched element will be taken.
 
 ```js
-const targetText = ""; //TODO: Specify a text that one of the cells in the desired row has.
+const targetTextList = ["<TODO: REPLACE>"]; //TODO: Specify a text that one of the cells in the desired row has. To specify more than one, add text to the array.
 const colIndex = 1; //TODO: Specify the column index of the desired cell that you want to interact with.
 
-const xpath = `//td[text()="${targetText}"]`;
+const trPredicates = targetTextList.map(targetText => `td[text()='${targetText}']`).join(' and ')
+const xpath = `//tr[${trPredicates}]`
 
 function getElementByXpath(xp) {
   return document.evaluate(
@@ -24,19 +26,9 @@ function getElementByXpath(xp) {
   ).singleNodeValue;
 }
 
-let tempElement = getElementByXpath(xpath);
+const tempElement = getElementByXpath(xpath);
 if(!tempElement) {
-  throw new Error(`Error: TD element not found (${xpath})`);
-}
-
-while(tempElement) {
-  tempElement = tempElement.parentElement;
-  if(tempElement.tagName === "TR") {
-    break;
-  }
-}
-if(!tempElement) {
-  throw new Error(`Error: TR element (row) not found (Parent or ancestor of ${xpath})`);
+  throw new Error(`Error: TR element not found (${xpath})`);
 }
 
 const selector = `td:nth-child(${colIndex})`;

--- a/content/ja/snippets/others/search_in_table_and_operate_specific_column.md
+++ b/content/ja/snippets/others/search_in_table_and_operate_specific_column.md
@@ -5,13 +5,15 @@ ie_support: false
 ---
 
 テーブル内をテキストで検索し、見つかった行の特定の列に対してテキストを取得したり、クリックするなどの操作を行います。
+複数のテキストでの検索も可能で、指定した全てのテキストを持つ行が対象になります。
 条件に当てはまる要素が複数ある場合、最初に見つかったものが使用されます。
 
 ```js
-const targetText = ""; //TODO: 探したいテキストを指定してください。そのテキストの属する行が対象になります。
+const targetTextList = ["<TODO: REPLACE>"]; //TODO: 探したいテキストを指定してください。そのテキストの属する行が対象になります。複数指定したい場合は配列にテキストを追加してください。
 const colIndex = 1; //TODO: 操作したいセルの列番号を指定してください。テキストで見つけた行の中の、何番目の列かを指定します。
 
-const xpath = `//td[text()="${targetText}"]`;
+const trPredicates = targetTextList.map(targetText => `td[text()='${targetText}']`).join(' and ')
+const xpath = `//tr[${trPredicates}]`
 
 function getElementByXpath(xp) {
   return document.evaluate(
@@ -23,19 +25,9 @@ function getElementByXpath(xp) {
   ).singleNodeValue;
 }
 
-let tempElement = getElementByXpath(xpath);
+const tempElement = getElementByXpath(xpath);
 if(!tempElement) {
-  throw new Error(`Error: TD element not found (${xpath})`);
-}
-
-while(tempElement) {
-  tempElement = tempElement.parentElement;
-  if(tempElement.tagName === "TR") {
-    break;
-  }
-}
-if(!tempElement) {
-  throw new Error(`Error: TR element (row) not found (Parent or ancestor of ${xpath})`);
+  throw new Error(`Error: TR element not found (${xpath})`);
 }
 
 const selector = `td:nth-child(${colIndex})`;


### PR DESCRIPTION
XPath has been modified so that the search logic for the parent tr element can be omitted.
Because some customers wanted to search in more than one text, I modified it to allow searching in more than one text.

Following code can also be omitted by using `//tr[${trPredicates}]/td[${colIndex}]`, but I have not dared to omit it in order to clarify whether the problem is with `targetTextList` or `colIndex` if there is an inquiry.
```
const selector = `td:nth-child(${colIndex})`;
const targetElement = tempElement.querySelector(selector);
if(!targetElement) {
  throw new Error(`Error: Element not found (${selector})`);
}
```