### PR TITLE
Drag and drop using MouseEventadd (Add clientX and clientY to the mousedown event)

### DIFF
--- a/content/en/snippets/mouse/drag_and_drop_by_mouse_event.md
+++ b/content/en/snippets/mouse/drag_and_drop_by_mouse_event.md
@@ -29,21 +29,28 @@ if (!dropArea) {
   throw new Error("Element not found by selector:", dropAreaSelector);
 }
 
-var coords = getCoordinates(dropArea);
+var dragCoords = getCoordinates(dragTarget)
+var dropCoords = getCoordinates(dropArea);
 
-dragTarget.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+dragTarget.dispatchEvent(
+  new MouseEvent("mousedown", {
+    bubbles: true,
+    clientX: dragCoords.x,
+    clientY: dragCoords.y
+  })
+);
 dragTarget.dispatchEvent(
   new MouseEvent("mousemove", {
     bubbles: true,
-    clientX: coords.x,
-    clientY: coords.y,
+    clientX: dropCoords.x,
+    clientY: dropCoords.y
   })
 );
 dragTarget.dispatchEvent(
   new MouseEvent("mouseup", {
     bubbles: true,
-    clientX: coords.x,
-    clientY: coords.y,
+    clientX: dropCoords.x,
+    clientY: dropCoords.y
   })
 );
 

--- a/content/ja/snippets/mouse/drag_and_drop_by_mouse_event.md
+++ b/content/ja/snippets/mouse/drag_and_drop_by_mouse_event.md
@@ -29,21 +29,28 @@ if (!dropArea) {
   throw new Error("Element not found by selector:", dropAreaSelector);
 }
 
-var coords = getCoordinates(dropArea);
+var dragCoords = getCoordinates(dragTarget)
+var dropCoords = getCoordinates(dropArea);
 
-dragTarget.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+dragTarget.dispatchEvent(
+  new MouseEvent("mousedown", {
+    bubbles: true,
+    clientX: dragCoords.x,
+    clientY: dragCoords.y
+  })
+);
 dragTarget.dispatchEvent(
   new MouseEvent("mousemove", {
     bubbles: true,
-    clientX: coords.x,
-    clientY: coords.y,
+    clientX: dropCoords.x,
+    clientY: dropCoords.y
   })
 );
 dragTarget.dispatchEvent(
   new MouseEvent("mouseup", {
     bubbles: true,
-    clientX: coords.x,
-    clientY: coords.y,
+    clientX: dropCoords.x,
+    clientY: dropCoords.y
   })
 );
 


### PR DESCRIPTION
I added `clientX` and `clientY` to the `mousedown` event because, with these attributes, the test became successful for a specific customer.

While there may be cases where `clientX` and `clientY` are not necessary, having them included in the `mousedown` event makes the version more closely resemble a real drag and drop operation, where `clientX` and `clientY` are present.