### PR TITLE
Update window.history.back() to autify.back()

### DIFF
--- a/content/en/snippets/others/back_forward_reload.md
+++ b/content/en/snippets/others/back_forward_reload.md
@@ -8,7 +8,7 @@ Simulate back, forward, reload on a browser.
 
 ```js
 /* Back */
-window.history.back();
+autify.back();
 
 /* Forward */
 window.history.forward();

--- a/content/ja/snippets/others/back_forward_reload.md
+++ b/content/ja/snippets/others/back_forward_reload.md
@@ -8,7 +8,7 @@ ie_support: true
 
 ```js
 /* 戻る */
-window.history.back();
+autify.back();
 
 /* 進む */
 window.history.forward();


### PR DESCRIPTION
We released `autify.back()`, which is safe to use instead of `window.history.back()` on Autify. Therefore, I updated the snippets.
https://help.autify.com/docs/release-notes-december-18th-2024